### PR TITLE
Fix tool handlers to return valid MCP CallToolResult responses

### DIFF
--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -68,67 +68,37 @@ export async function setupRequestHandlers(
       switch (toolName) {
         case "send-email":
           return await handleSendEmail(toolParams);
-        
+
         case "send-bulk-emails":
           return await handleSendBulkEmails(toolParams);
-        
+
         case "get-smtp-configs":
           return await handleGetSmtpConfigs();
-        
+
         case "add-smtp-config":
           return await handleAddSmtpConfig(toolParams);
-        
+
         case "update-smtp-config":
           return await handleUpdateSmtpConfig(toolParams);
-        
+
         case "delete-smtp-config":
           return await handleDeleteSmtpConfig(toolParams);
-        
+
         case "get-email-templates":
           return await handleGetEmailTemplates();
-        
+
         case "add-email-template":
           return await handleAddEmailTemplate(toolParams);
-        
+
         case "update-email-template":
           return await handleUpdateEmailTemplate(toolParams);
-        
+
         case "delete-email-template":
           return await handleDeleteEmailTemplate(toolParams);
-        
-        case "get-email-logs": {
-          const { limit, filterBySuccess } = toolParams as { 
-            limit?: number;
-            filterBySuccess?: boolean;
-          };
-          
-          try {
-            let logs = await getEmailLogs();
-            
-            // Filter by success status if specified
-            if (filterBySuccess !== undefined) {
-              logs = logs.filter((log: EmailLogEntry) => log.success === filterBySuccess);
-            }
-            
-            // Sort by timestamp in descending order (newest first)
-            logs = logs.sort((a: EmailLogEntry, b: EmailLogEntry) => 
-              new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-            );
-            
-            // Limit the number of results if specified
-            if (limit && limit > 0) {
-              logs = logs.slice(0, limit);
-            }
-            
-            return {
-              result: logs
-            };
-          } catch (error) {
-            logToFile(`Error getting email logs: ${error}`);
-            throw new Error("Failed to retrieve email logs");
-          }
-        }
-        
+
+        case "get-email-logs":
+          return await handleGetEmailLogs(toolParams);
+
         default:
           throw new Error(`Tool '${toolName}' exists but no handler is implemented`);
       }
@@ -141,10 +111,8 @@ export async function setupRequestHandlers(
  */
 async function handleSendEmail(parameters: any) {
   try {
-    // If "to" is a single object, convert it to an array
     const to = Array.isArray(parameters.to) ? parameters.to : [parameters.to];
-    
-    // Prepare the email data
+
     const emailData: EmailData = {
       to: to,
       subject: parameters.subject,
@@ -155,20 +123,18 @@ async function handleSendEmail(parameters: any) {
       templateId: parameters.templateId,
       templateData: parameters.templateData
     };
-    
-    // Send the email
+
     const result = await sendEmail(emailData, parameters.smtpConfigId);
-    
+
     return {
-      success: result.success,
-      message: result.message
+      content: [{ type: "text" as const, text: JSON.stringify({ success: result.success, message: result.message }, null, 2) }]
     };
   } catch (error) {
     logToFile('Error in handleSendEmail:');
     logToFile(error instanceof Error ? error.message : 'Unknown error');
     return {
-      success: false,
-      message: error instanceof Error ? error.message : 'Unknown error'
+      content: [{ type: "text" as const, text: JSON.stringify({ success: false, message: error instanceof Error ? error.message : 'Unknown error' }, null, 2) }],
+      isError: true
     };
   }
 }
@@ -178,7 +144,6 @@ async function handleSendEmail(parameters: any) {
  */
 async function handleSendBulkEmails(parameters: any) {
   try {
-    // Prepare the bulk email data
     const bulkEmailData: BulkEmailData = {
       recipients: parameters.recipients,
       subject: parameters.subject,
@@ -191,25 +156,24 @@ async function handleSendBulkEmails(parameters: any) {
       batchSize: parameters.batchSize,
       delayBetweenBatches: parameters.delayBetweenBatches
     };
-    
-    // Send the bulk emails
+
     const result = await sendBulkEmails(bulkEmailData, parameters.smtpConfigId);
-    
+
     return {
-      success: result.success,
-      totalSent: result.totalSent,
-      totalFailed: result.totalFailed,
-      failures: result.failures,
-      message: result.message
+      content: [{ type: "text" as const, text: JSON.stringify({
+        success: result.success, totalSent: result.totalSent, totalFailed: result.totalFailed,
+        failures: result.failures, message: result.message
+      }, null, 2) }]
     };
   } catch (error) {
     logToFile('Error in handleSendBulkEmails:');
     logToFile(error instanceof Error ? error.message : 'Unknown error');
     return {
-      success: false,
-      totalSent: 0,
-      totalFailed: parameters.recipients?.length || 0,
-      message: error instanceof Error ? error.message : 'Unknown error'
+      content: [{ type: "text" as const, text: JSON.stringify({
+        success: false, totalSent: 0, totalFailed: parameters.recipients?.length || 0,
+        message: error instanceof Error ? error.message : 'Unknown error'
+      }, null, 2) }],
+      isError: true
     };
   }
 }
@@ -220,17 +184,16 @@ async function handleSendBulkEmails(parameters: any) {
 async function handleGetSmtpConfigs() {
   try {
     const configs = await getSmtpConfigs();
-    
+
     return {
-      success: true,
-      configs: configs
+      content: [{ type: "text" as const, text: JSON.stringify({ success: true, configs }, null, 2) }]
     };
   } catch (error) {
     logToFile('Error in handleGetSmtpConfigs:');
     logToFile(error instanceof Error ? error.message : 'Unknown error');
     return {
-      success: false,
-      message: error instanceof Error ? error.message : 'Unknown error'
+      content: [{ type: "text" as const, text: JSON.stringify({ success: false, message: error instanceof Error ? error.message : 'Unknown error' }, null, 2) }],
+      isError: true
     };
   }
 }
@@ -240,10 +203,8 @@ async function handleGetSmtpConfigs() {
  */
 async function handleAddSmtpConfig(parameters: any) {
   try {
-    // Get existing configs
     const configs = await getSmtpConfigs();
-    
-    // Create a new config
+
     const newConfig: SmtpServerConfig = {
       id: generateUUID(),
       name: parameters.name,
@@ -256,30 +217,23 @@ async function handleAddSmtpConfig(parameters: any) {
       },
       isDefault: parameters.isDefault ?? false
     };
-    
-    // If this is set as default, update other configs
+
     if (newConfig.isDefault) {
-      configs.forEach(config => {
-        config.isDefault = false;
-      });
+      configs.forEach(config => { config.isDefault = false; });
     }
-    
-    // Add the new config to the list
+
     configs.push(newConfig);
-    
-    // Save the updated configs
     await saveSmtpConfigs(configs);
-    
+
     return {
-      success: true,
-      config: newConfig
+      content: [{ type: "text" as const, text: JSON.stringify({ success: true, config: newConfig }, null, 2) }]
     };
   } catch (error) {
     logToFile('Error in handleAddSmtpConfig:');
     logToFile(error instanceof Error ? error.message : 'Unknown error');
     return {
-      success: false,
-      message: error instanceof Error ? error.message : 'Unknown error'
+      content: [{ type: "text" as const, text: JSON.stringify({ success: false, message: error instanceof Error ? error.message : 'Unknown error' }, null, 2) }],
+      isError: true
     };
   }
 }
@@ -289,59 +243,46 @@ async function handleAddSmtpConfig(parameters: any) {
  */
 async function handleUpdateSmtpConfig(parameters: any) {
   try {
-    // Get existing configs
     const configs = await getSmtpConfigs();
-    
-    // Find the config to update
     const configIndex = configs.findIndex(config => config.id === parameters.id);
-    
+
     if (configIndex === -1) {
       return {
-        success: false,
-        message: `SMTP configuration with ID ${parameters.id} not found`
+        content: [{ type: "text" as const, text: JSON.stringify({ success: false, message: `SMTP configuration with ID ${parameters.id} not found` }, null, 2) }],
+        isError: true
       };
     }
-    
-    // Update the config
+
     const updatedConfig = { ...configs[configIndex] };
-    
+
     if (parameters.name !== undefined) updatedConfig.name = parameters.name;
     if (parameters.host !== undefined) updatedConfig.host = parameters.host;
     if (parameters.port !== undefined) updatedConfig.port = parameters.port;
     if (parameters.secure !== undefined) updatedConfig.secure = parameters.secure;
     if (parameters.user !== undefined) updatedConfig.auth.user = parameters.user;
     if (parameters.pass !== undefined) updatedConfig.auth.pass = parameters.pass;
-    
-    // Handle default flag
+
     if (parameters.isDefault !== undefined) {
       updatedConfig.isDefault = parameters.isDefault;
-      
-      // If setting as default, update other configs
       if (updatedConfig.isDefault) {
         configs.forEach((config, index) => {
-          if (index !== configIndex) {
-            config.isDefault = false;
-          }
+          if (index !== configIndex) config.isDefault = false;
         });
       }
     }
-    
-    // Update the config in the list
+
     configs[configIndex] = updatedConfig;
-    
-    // Save the updated configs
     await saveSmtpConfigs(configs);
-    
+
     return {
-      success: true,
-      config: updatedConfig
+      content: [{ type: "text" as const, text: JSON.stringify({ success: true, config: updatedConfig }, null, 2) }]
     };
   } catch (error) {
     logToFile('Error in handleUpdateSmtpConfig:');
     logToFile(error instanceof Error ? error.message : 'Unknown error');
     return {
-      success: false,
-      message: error instanceof Error ? error.message : 'Unknown error'
+      content: [{ type: "text" as const, text: JSON.stringify({ success: false, message: error instanceof Error ? error.message : 'Unknown error' }, null, 2) }],
+      isError: true
     };
   }
 }
@@ -351,51 +292,41 @@ async function handleUpdateSmtpConfig(parameters: any) {
  */
 async function handleDeleteSmtpConfig(parameters: any) {
   try {
-    // Get existing configs
     const configs = await getSmtpConfigs();
-    
-    // Find the config to delete
     const configIndex = configs.findIndex(config => config.id === parameters.id);
-    
+
     if (configIndex === -1) {
       return {
-        success: false,
-        message: `SMTP configuration with ID ${parameters.id} not found`
+        content: [{ type: "text" as const, text: JSON.stringify({ success: false, message: `SMTP configuration with ID ${parameters.id} not found` }, null, 2) }],
+        isError: true
       };
     }
-    
-    // Check if trying to delete the only config
+
     if (configs.length === 1) {
       return {
-        success: false,
-        message: 'Cannot delete the only SMTP configuration'
+        content: [{ type: "text" as const, text: JSON.stringify({ success: false, message: 'Cannot delete the only SMTP configuration' }, null, 2) }],
+        isError: true
       };
     }
-    
-    // Check if deleting the default config
+
     const isDefault = configs[configIndex].isDefault;
-    
-    // Remove the config from the list
     configs.splice(configIndex, 1);
-    
-    // If deleting the default config, set another one as default
+
     if (isDefault && configs.length > 0) {
       configs[0].isDefault = true;
     }
-    
-    // Save the updated configs
+
     await saveSmtpConfigs(configs);
-    
+
     return {
-      success: true,
-      message: 'SMTP configuration deleted successfully'
+      content: [{ type: "text" as const, text: JSON.stringify({ success: true, message: 'SMTP configuration deleted successfully' }, null, 2) }]
     };
   } catch (error) {
     logToFile('Error in handleDeleteSmtpConfig:');
     logToFile(error instanceof Error ? error.message : 'Unknown error');
     return {
-      success: false,
-      message: error instanceof Error ? error.message : 'Unknown error'
+      content: [{ type: "text" as const, text: JSON.stringify({ success: false, message: error instanceof Error ? error.message : 'Unknown error' }, null, 2) }],
+      isError: true
     };
   }
 }
@@ -406,17 +337,16 @@ async function handleDeleteSmtpConfig(parameters: any) {
 async function handleGetEmailTemplates() {
   try {
     const templates = await getEmailTemplates();
-    
+
     return {
-      success: true,
-      templates: templates
+      content: [{ type: "text" as const, text: JSON.stringify({ success: true, templates }, null, 2) }]
     };
   } catch (error) {
     logToFile('Error in handleGetEmailTemplates:');
     logToFile(error instanceof Error ? error.message : 'Unknown error');
     return {
-      success: false,
-      message: error instanceof Error ? error.message : 'Unknown error'
+      content: [{ type: "text" as const, text: JSON.stringify({ success: false, message: error instanceof Error ? error.message : 'Unknown error' }, null, 2) }],
+      isError: true
     };
   }
 }
@@ -426,10 +356,8 @@ async function handleGetEmailTemplates() {
  */
 async function handleAddEmailTemplate(parameters: any) {
   try {
-    // Get existing templates
     const templates = await getEmailTemplates();
-    
-    // Create a new template
+
     const newTemplate: EmailTemplate = {
       id: generateUUID(),
       name: parameters.name,
@@ -437,8 +365,7 @@ async function handleAddEmailTemplate(parameters: any) {
       body: parameters.body,
       isDefault: parameters.isDefault ?? false
     };
-    
-    // If this is set as default, we'll need to update other templates
+
     if (newTemplate.isDefault) {
       templates.forEach(template => {
         if (template.isDefault) {
@@ -450,20 +377,18 @@ async function handleAddEmailTemplate(parameters: any) {
         }
       });
     }
-    
-    // Save the new template
+
     await saveEmailTemplate(newTemplate);
-    
+
     return {
-      success: true,
-      template: newTemplate
+      content: [{ type: "text" as const, text: JSON.stringify({ success: true, template: newTemplate }, null, 2) }]
     };
   } catch (error) {
     logToFile('Error in handleAddEmailTemplate:');
     logToFile(error instanceof Error ? error.message : 'Unknown error');
     return {
-      success: false,
-      message: error instanceof Error ? error.message : 'Unknown error'
+      content: [{ type: "text" as const, text: JSON.stringify({ success: false, message: error instanceof Error ? error.message : 'Unknown error' }, null, 2) }],
+      isError: true
     };
   }
 }
@@ -473,31 +398,24 @@ async function handleAddEmailTemplate(parameters: any) {
  */
 async function handleUpdateEmailTemplate(parameters: any) {
   try {
-    // Get existing templates
     const templates = await getEmailTemplates();
-    
-    // Find the template to update
     const template = templates.find(t => t.id === parameters.id);
-    
+
     if (!template) {
       return {
-        success: false,
-        message: `Email template with ID ${parameters.id} not found`
+        content: [{ type: "text" as const, text: JSON.stringify({ success: false, message: `Email template with ID ${parameters.id} not found` }, null, 2) }],
+        isError: true
       };
     }
-    
-    // Update the template
+
     const updatedTemplate = { ...template };
-    
+
     if (parameters.name !== undefined) updatedTemplate.name = parameters.name;
     if (parameters.subject !== undefined) updatedTemplate.subject = parameters.subject;
     if (parameters.body !== undefined) updatedTemplate.body = parameters.body;
-    
-    // Handle default flag
+
     if (parameters.isDefault !== undefined && parameters.isDefault !== template.isDefault) {
       updatedTemplate.isDefault = parameters.isDefault;
-      
-      // If setting as default, update other templates
       if (updatedTemplate.isDefault) {
         templates.forEach(t => {
           if (t.id !== parameters.id && t.isDefault) {
@@ -510,20 +428,18 @@ async function handleUpdateEmailTemplate(parameters: any) {
         });
       }
     }
-    
-    // Save the updated template
+
     await saveEmailTemplate(updatedTemplate);
-    
+
     return {
-      success: true,
-      template: updatedTemplate
+      content: [{ type: "text" as const, text: JSON.stringify({ success: true, template: updatedTemplate }, null, 2) }]
     };
   } catch (error) {
     logToFile('Error in handleUpdateEmailTemplate:');
     logToFile(error instanceof Error ? error.message : 'Unknown error');
     return {
-      success: false,
-      message: error instanceof Error ? error.message : 'Unknown error'
+      content: [{ type: "text" as const, text: JSON.stringify({ success: false, message: error instanceof Error ? error.message : 'Unknown error' }, null, 2) }],
+      isError: true
     };
   }
 }
@@ -533,20 +449,16 @@ async function handleUpdateEmailTemplate(parameters: any) {
  */
 async function handleDeleteEmailTemplate(parameters: any) {
   try {
-    // Get existing templates
     const templates = await getEmailTemplates();
-    
-    // Find the template to delete
     const template = templates.find(t => t.id === parameters.id);
-    
+
     if (!template) {
       return {
-        success: false,
-        message: `Email template with ID ${parameters.id} not found`
+        content: [{ type: "text" as const, text: JSON.stringify({ success: false, message: `Email template with ID ${parameters.id} not found` }, null, 2) }],
+        isError: true
       };
     }
-    
-    // If deleting default template, make another one default
+
     if (template.isDefault && templates.length > 1) {
       const anotherTemplate = templates.find(t => t.id !== parameters.id);
       if (anotherTemplate) {
@@ -554,20 +466,54 @@ async function handleDeleteEmailTemplate(parameters: any) {
         await saveEmailTemplate(anotherTemplate);
       }
     }
-    
-    // Delete the template
+
     await deleteEmailTemplate(parameters.id);
-    
+
     return {
-      success: true,
-      message: 'Email template deleted successfully'
+      content: [{ type: "text" as const, text: JSON.stringify({ success: true, message: 'Email template deleted successfully' }, null, 2) }]
     };
   } catch (error) {
     logToFile('Error in handleDeleteEmailTemplate:');
     logToFile(error instanceof Error ? error.message : 'Unknown error');
     return {
-      success: false,
-      message: error instanceof Error ? error.message : 'Unknown error'
+      content: [{ type: "text" as const, text: JSON.stringify({ success: false, message: error instanceof Error ? error.message : 'Unknown error' }, null, 2) }],
+      isError: true
     };
   }
-} 
+}
+
+/**
+ * Handle get-email-logs tool call
+ */
+async function handleGetEmailLogs(parameters: any) {
+  try {
+    const { limit, filterBySuccess } = parameters as {
+      limit?: number;
+      filterBySuccess?: boolean;
+    };
+
+    let logs = await getEmailLogs();
+
+    if (filterBySuccess !== undefined) {
+      logs = logs.filter((log: EmailLogEntry) => log.success === filterBySuccess);
+    }
+
+    logs = logs.sort((a: EmailLogEntry, b: EmailLogEntry) =>
+      new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+    );
+
+    if (limit && limit > 0) {
+      logs = logs.slice(0, limit);
+    }
+
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ success: true, logs }, null, 2) }]
+    };
+  } catch (error) {
+    logToFile(`Error getting email logs: ${error}`);
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify({ success: false, message: error instanceof Error ? error.message : 'Failed to retrieve email logs' }, null, 2) }],
+      isError: true
+    };
+  }
+}


### PR DESCRIPTION
## Summary

All tool handlers were returning plain objects (e.g. `{ success: true, configs: [...] }`) instead of the `CallToolResult` format required by the MCP SDK:

```json
{ "content": [{ "type": "text", "text": "..." }] }
```
This caused MCP clients to receive empty responses when calling any tool.

Changes

- Updated all 11 tool handlers in requestHandler.ts to return { content: [{ type: "text", text: JSON.stringify(...) }] }
- Error responses now include isError: true
- Extracted inline get-email-logs handler into its own handleGetEmailLogs function for consistency
