### PR TITLE
fix: return spec-compliant CallToolResult from tool handlers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ async function runServer() {
     logToFile("SMTP MCP Server started successfully");
     
     // Keep the process alive when run directly
-    console.log("SMTP MCP Server running. Press Ctrl+C to exit.");
+    console.error("SMTP MCP Server running. Press Ctrl+C to exit.");
     
     // Handle stdin to keep the process running
     process.stdin.resume();

--- a/src/requestHandler.ts
+++ b/src/requestHandler.ts
@@ -56,84 +56,97 @@ export async function setupRequestHandlers(
   server.setRequestHandler(
     CallToolRequestSchema,
     async (request) => {
-      const toolName = request.params.name;
-      const toolParams = request.params.arguments || {};
+      const result = await dispatchTool(
+        tools,
+        request.params.name,
+        request.params.arguments || {}
+      );
 
-      // Check if the tool exists
-      if (!tools[toolName]) {
-        throw new Error(`Tool '${toolName}' not found`);
-      }
-
-      // Execute the tool based on its name
-      switch (toolName) {
-        case "send-email":
-          return await handleSendEmail(toolParams);
-        
-        case "send-bulk-emails":
-          return await handleSendBulkEmails(toolParams);
-        
-        case "get-smtp-configs":
-          return await handleGetSmtpConfigs();
-        
-        case "add-smtp-config":
-          return await handleAddSmtpConfig(toolParams);
-        
-        case "update-smtp-config":
-          return await handleUpdateSmtpConfig(toolParams);
-        
-        case "delete-smtp-config":
-          return await handleDeleteSmtpConfig(toolParams);
-        
-        case "get-email-templates":
-          return await handleGetEmailTemplates();
-        
-        case "add-email-template":
-          return await handleAddEmailTemplate(toolParams);
-        
-        case "update-email-template":
-          return await handleUpdateEmailTemplate(toolParams);
-        
-        case "delete-email-template":
-          return await handleDeleteEmailTemplate(toolParams);
-        
-        case "get-email-logs": {
-          const { limit, filterBySuccess } = toolParams as { 
-            limit?: number;
-            filterBySuccess?: boolean;
-          };
-          
-          try {
-            let logs = await getEmailLogs();
-            
-            // Filter by success status if specified
-            if (filterBySuccess !== undefined) {
-              logs = logs.filter((log: EmailLogEntry) => log.success === filterBySuccess);
-            }
-            
-            // Sort by timestamp in descending order (newest first)
-            logs = logs.sort((a: EmailLogEntry, b: EmailLogEntry) => 
-              new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-            );
-            
-            // Limit the number of results if specified
-            if (limit && limit > 0) {
-              logs = logs.slice(0, limit);
-            }
-            
-            return {
-              result: logs
-            };
-          } catch (error) {
-            logToFile(`Error getting email logs: ${error}`);
-            throw new Error("Failed to retrieve email logs");
-          }
-        }
-        
-        default:
-          throw new Error(`Tool '${toolName}' exists but no handler is implemented`);
-      }
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+      };
     }
   );
+}
+
+async function dispatchTool(
+  tools: Record<string, Tool>,
+  toolName: string,
+  toolParams: any,
+): Promise<unknown> {
+  // Check if the tool exists
+  if (!tools[toolName]) {
+    throw new Error(`Tool '${toolName}' not found`);
+  }
+
+  // Execute the tool based on its name
+  switch (toolName) {
+    case "send-email":
+      return await handleSendEmail(toolParams);
+
+    case "send-bulk-emails":
+      return await handleSendBulkEmails(toolParams);
+
+    case "get-smtp-configs":
+      return await handleGetSmtpConfigs();
+
+    case "add-smtp-config":
+      return await handleAddSmtpConfig(toolParams);
+
+    case "update-smtp-config":
+      return await handleUpdateSmtpConfig(toolParams);
+
+    case "delete-smtp-config":
+      return await handleDeleteSmtpConfig(toolParams);
+
+    case "get-email-templates":
+      return await handleGetEmailTemplates();
+
+    case "add-email-template":
+      return await handleAddEmailTemplate(toolParams);
+
+    case "update-email-template":
+      return await handleUpdateEmailTemplate(toolParams);
+
+    case "delete-email-template":
+      return await handleDeleteEmailTemplate(toolParams);
+
+    case "get-email-logs": {
+      const { limit, filterBySuccess } = toolParams as {
+        limit?: number;
+        filterBySuccess?: boolean;
+      };
+
+      try {
+        let logs = await getEmailLogs();
+
+        // Filter by success status if specified
+        if (filterBySuccess !== undefined) {
+          logs = logs.filter((log: EmailLogEntry) => log.success === filterBySuccess);
+        }
+
+        // Sort by timestamp in descending order (newest first)
+        logs = logs.sort((a: EmailLogEntry, b: EmailLogEntry) =>
+          new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+        );
+
+        // Limit the number of results if specified
+        if (limit && limit > 0) {
+          logs = logs.slice(0, limit);
+        }
+
+        return {
+          result: logs
+        };
+      } catch (error) {
+        logToFile(`Error getting email logs: ${error}`);
+        throw new Error("Failed to retrieve email logs");
+      }
+    }
+
+    default:
+      throw new Error(`Tool '${toolName}' exists but no handler is implemented`);
+  }
 }
 
 /**


### PR DESCRIPTION
Every tool handler returns a bare object instead of an MCP `CallToolResult`, so the client gets a response with no `content` array and renders nothing. The tool actually runs and the side effect happens, but the caller sees a blank result and reasonably concludes it failed.

From `handleGetSmtpConfigs`:

```ts
return { success: true, configs: configs };
```

and `get-email-logs`:

```ts
return { result: logs };
```

The spec wants `{ content: [{ type: "text", text: "..." }] }`. The dispatcher in `setupRequestHandlers` passed those through untouched.

This is worst on `send-email`. The mail goes out, `email-logs.json` records it with `success: true`, and the tool response is still empty. I spent a while convinced a send had failed when it had not.

## Changes

**1. Wrap tool results in a content array.** Extracted the switch out of the `CallToolRequestSchema` callback into a `dispatchTool` helper, then wrapped its return value once at the call site. One place, covers all 11 tools, no per-handler edits and no behavior change inside the handlers.

**2. Startup log goes to stderr.** `console.log` on a stdio server writes into the JSON-RPC stream and can corrupt the first message a client parses. Changed to `console.error`.

## Testing

`npm run build` passes clean. Drove the built server over stdio with a real `initialize` and `tools/call` for `get-smtp-configs`:

```
has content array: True
{
  "success": true,
  "configs": [ ... ]
}
```

Before the change the same call returned a result with no `content` key at all.
